### PR TITLE
Add (setVolume:) (getContentType) (getFileExtension) for FSAudioStream

### DIFF
--- a/Common/FSAudioStream.h
+++ b/Common/FSAudioStream.h
@@ -109,6 +109,21 @@ typedef struct {
 - (void)pause;
 
 /**
+ * Set audio stream volume from 0.0 to 1.0.
+ */
+- (void)setVolume:(float)volume;
+
+/**
+ * Receive content type of audio stream like @"audio/mpeg"
+ */
+- (NSString *)getContentType;
+
+/**
+ * Receive file extension of audio stream like @"mp3"
+ */
+- (NSString *)getFileExtension;
+
+/**
  * Seeks the stream to a given position. Requires a non-continuous stream
  * (a stream with a known duration).
  *

--- a/Common/FSAudioStream.mm
+++ b/Common/FSAudioStream.mm
@@ -87,6 +87,8 @@ public:
 - (void)seekToTime:(unsigned)newSeekTime;
 - (unsigned)timePlayedInSeconds;
 - (unsigned)durationInSeconds;
+- (void)setVolume:(float)volume;
+- (NSString *)getContentType;
 @end
 
 @implementation FSAudioStreamPrivate
@@ -327,6 +329,73 @@ public:
     return _audioStream->durationInSeconds();
 }
 
+- (void)setVolume:(float)volume
+{
+    _audioStream->setVolume(volume);
+}
+
+- (NSString *)getContentType
+{
+    std::string param = _audioStream->getContentType();
+    
+    return [NSString stringWithUTF8String:param.c_str()];
+}
+
+- (NSString *)getFileExtension
+{
+    NSString *contentType = [self getContentType];
+    NSString *fileExtension;
+    
+    if ([contentType isEqualToString:@"audio/mpeg"])
+    {
+        fileExtension = @"mp3";
+        NSLog(@"kAudioFileMP3Type detected\n");
+    }
+    else if ([contentType isEqualToString:@"audio/x-wav"])
+    {
+        fileExtension = @"wav";
+        NSLog(@"kAudioFileWAVEType detected\n");
+    }
+    else if ([contentType isEqualToString:@"audio/x-aifc"])
+    {
+        fileExtension = @"aifc";
+        NSLog(@"kAudioFileAIFCType detected\n");
+    }
+    else if ([contentType isEqualToString:@"audio/x-aiff"])
+    {
+        fileExtension = @"aiff";
+        NSLog(@"kAudioFileAIFFType detected\n");
+    }
+    else if ([contentType isEqualToString:@"audio/x-m4a"])
+    {
+        fileExtension = @"m4a";
+        NSLog(@"kAudioFileM4AType detected\n");
+    }
+    else if ([contentType isEqualToString:@"audio/mp4"])
+    {
+        fileExtension = @"mp4";
+        NSLog(@"kAudioFileMPEG4Type detected\n");
+    }
+    else if ([contentType isEqualToString:@"audio/x-caf"])
+    {
+        fileExtension = @"caf";
+        NSLog(@"kAudioFileCAFType detected\n");
+    }
+    else if ([contentType isEqualToString:@"audio/aac"] ||
+             [contentType isEqualToString:@"audio/aacp"])
+    {
+        fileExtension = @"aac";
+        NSLog(@"kAudioFileAAC_ADTSType detected\n");
+    }
+    else
+    {
+        fileExtension = nil;
+        NSLog(@"Unable to detect the audio stream type from content-type %@\n", contentType);
+    }
+    
+    return fileExtension;
+}
+
 @end
 
 /*
@@ -451,6 +520,21 @@ public:
     
     FSStreamPosition pos = {.minute = m, .second = s};
     return pos;
+}
+
+- (void)setVolume:(float)volume
+{
+    [_private setVolume:volume];
+}
+
+- (NSString *)getContentType
+{
+    return [_private getContentType];
+}
+
+- (NSString *)getFileExtension
+{
+    return [_private getFileExtension];
 }
 
 - (BOOL)continuous

--- a/astreamer/audio_queue.cpp
+++ b/astreamer/audio_queue.cpp
@@ -98,6 +98,11 @@ void Audio_Queue::stop()
 {
     stop(true);
 }
+    
+void Audio_Queue::setVolume(float volume)
+{
+    AudioQueueSetParameter(m_outAQ, kAudioQueueParam_Volume, volume);
+}
 
 void Audio_Queue::stop(bool stopImmediately)
 {

--- a/astreamer/audio_queue.h
+++ b/astreamer/audio_queue.h
@@ -46,6 +46,8 @@ public:
     void stop(bool stopImmediately);
     void stop();
     
+    void setVolume(float volume);
+    
     unsigned timePlayedInSeconds();
 	
 private:

--- a/astreamer/audio_stream.cpp
+++ b/astreamer/audio_stream.cpp
@@ -238,6 +238,16 @@ void Audio_Stream::seekToTime(unsigned newSeekTime)
     }
 }
     
+void Audio_Stream::setVolume(float volume)
+{
+    if (m_audioQueue) m_audioQueue->setVolume(volume);
+}
+    
+std::string Audio_Stream::getContentType()
+{
+    return m_contentType;
+}
+    
 void Audio_Stream::setUrl(CFURLRef url)
 {
     m_httpStream->setUrl(url);
@@ -311,6 +321,8 @@ AudioFileTypeID Audio_Stream::audioStreamTypeFromContentType(std::string content
     } else {
         AS_TRACE("***** Unable to detect the audio stream type from content-type %s *****\n", contentType.c_str());
     }
+    
+    m_contentType = contentType;
     
 out:
     return fileTypeHint;        

--- a/astreamer/audio_stream.h
+++ b/astreamer/audio_stream.h
@@ -58,6 +58,9 @@ public:
     unsigned durationInSeconds();
     void seekToTime(unsigned newSeekTime);
     
+    void setVolume(float volume);
+    std::string getContentType();
+    
     void setUrl(CFURLRef url);
     void setStrictContentTypeChecking(bool strictChecking);
     void setDefaultContentType(std::string& defaultContentType);
@@ -109,6 +112,7 @@ private:
     
     bool m_strictContentTypeChecking;
     std::string m_defaultContentType;
+    std::string m_contentType;
     
     File_Output *m_fileOutput;
     


### PR DESCRIPTION
(setVolume:) need to control sound volume
(getContentType) (getFileExtension) need to get file extension of audio stream, like @"mp3" or @"aac" to record and play recorded file, because, for example:

AVPlayer will not play file like "track", but will play file "track.mp3", but if file extension wrong it will not play again. That's why we need to be able get file extension of current recorded file
