### PR TITLE
fix retry when network error happen in the very first time buffing

### DIFF
--- a/Common/FSAudioStream.h
+++ b/Common/FSAudioStream.h
@@ -53,6 +53,9 @@ typedef enum {
     kFsAudioStreamSeeking,
     kFSAudioStreamEndOfFile,
     kFsAudioStreamFailed,
+    kFsAudioStreamStartRetry,
+    kFsAudioStreamRetrySuccess,
+    kFsAudioStreamAllRetryFailed,
     kFsAudioStreamPlaybackCompleted,
     kFsAudioStreamUnknownState
 } FSAudioStreamState;
@@ -293,6 +296,11 @@ NSString*             freeStreamerReleaseVersion();
 - (void)setPlayRate:(float)playRate;
 
 /**
+ * For clean retry count
+ * @param restartCount The retry count.
+ */
+- (void)setRetryCount:(int)retryCount;
+/**
  * Returns the playback status: YES if the stream is playing, NO otherwise.
  */
 - (BOOL)isPlaying;
@@ -301,6 +309,11 @@ NSString*             freeStreamerReleaseVersion();
  * Cleans all cached data from the persistent storage.
  */
 - (void)expungeCache;
+
+/**
+ * Get current retry count.
+ */
+- (NSUInteger)retryCount;
 
 /**
  * The stream URL.

--- a/Common/FSAudioStream.mm
+++ b/Common/FSAudioStream.mm
@@ -1399,12 +1399,11 @@ void AudioStreamStateObserver::audioStreamStateChanged(astreamer::Audio_Stream::
             notificationHandler = @selector(notifyPlaybackStopped);
             break;
         case astreamer::Audio_Stream::BUFFERING:
+            priv.internetConnectionAvailable = YES;            
             notificationHandler = @selector(notifyPlaybackBuffering);
             break;
         case astreamer::Audio_Stream::PLAYING:
-            priv.internetConnectionAvailable = YES;
             priv.restartCount = 0;
-            
             notificationHandler = @selector(notifyPlaybackPlaying);
             break;
         case astreamer::Audio_Stream::PAUSED:

--- a/Common/FSAudioStream.mm
+++ b/Common/FSAudioStream.mm
@@ -211,6 +211,7 @@ public:
 @property (nonatomic,assign) BOOL wasDisconnected;
 @property (nonatomic,assign) BOOL wasContinuousStream;
 @property (nonatomic,assign) BOOL internetConnectionAvailable;
+@property (nonatomic,assign) NSUInteger maxRetryCount;
 @property (nonatomic,assign) NSUInteger restartCount;
 @property (readonly) size_t prebufferedByteCount;
 @property (readonly) FSSeekByteOffset currentSeekByteOffset;
@@ -298,6 +299,7 @@ public:
                                                      name:AVAudioSessionInterruptionNotification
                                                    object:nil];
 #endif
+        _maxRetryCount = 3;
     }
     return self;
 }
@@ -712,6 +714,7 @@ public:
 
 - (void)notifyPlaybackBuffering
 {
+    self.internetConnectionAvailable = YES;
     [self notifyStateChange:kFsAudioStreamBuffering];
 }
 
@@ -723,7 +726,10 @@ public:
         fsAudioStreamPrivateActiveSessions[[NSNumber numberWithUnsignedLong:(unsigned long)self]] = @"";
     }
 #endif
-    
+    if (self.restartCount > 0){
+        [self notifyStateChange:kFsAudioStreamRetrySuccess];
+    }
+    self.restartCount = 0;
     [self notifyStateChange:kFsAudioStreamPlaying];
 }
 
@@ -800,10 +806,11 @@ public:
         return;
     }
     
-    if (self.restartCount >= 3) {
+    if (self.restartCount >= self.maxRetryCount) {
 #if defined(DEBUG) || (TARGET_IPHONE_SIMULATOR)
         NSLog(@"FSAudioStream: Restart count %lu. Giving up.", (unsigned long)_restartCount);
 #endif
+        [self notifyStateChange:kFsAudioStreamAllRetryFailed];
         return;
     }
     
@@ -811,6 +818,7 @@ public:
     NSLog(@"FSAudioStream: Attempting restart.");
 #endif
     
+    [self notifyStateChange:kFsAudioStreamStartRetry];
     [NSTimer scheduledTimerWithTimeInterval:1
                                      target:self
                                    selector:@selector(play)
@@ -1144,6 +1152,9 @@ public:
 {
     [_private setPlayRate:playRate];
 }
+- (void)setRetryCount:(int)retryCount{
+    _private.restartCount = retryCount;
+}
 
 - (BOOL)isPlaying
 {
@@ -1154,6 +1165,10 @@ public:
 {
     [_private expungeCache];
 }
+- (NSUInteger)retryCount{
+    return _private.restartCount;
+}
+
 
 - (FSStreamPosition)currentTimePlayed
 {
@@ -1399,11 +1414,9 @@ void AudioStreamStateObserver::audioStreamStateChanged(astreamer::Audio_Stream::
             notificationHandler = @selector(notifyPlaybackStopped);
             break;
         case astreamer::Audio_Stream::BUFFERING:
-            priv.internetConnectionAvailable = YES;            
             notificationHandler = @selector(notifyPlaybackBuffering);
             break;
         case astreamer::Audio_Stream::PLAYING:
-            priv.restartCount = 0;
             notificationHandler = @selector(notifyPlaybackPlaying);
             break;
         case astreamer::Audio_Stream::PAUSED:


### PR DESCRIPTION
Issue happen is following steps
1. Start to play a URL for the very first time.
2. When start to buffering the audio, and network error occurs.
3. It won't retry for 3 times, freestreamer will directly fail.