### PR TITLE
add new function and fix a issue

### DIFF
--- a/Common/FSAudioController.m
+++ b/Common/FSAudioController.m
@@ -95,6 +95,17 @@
         
         __weak FSAudioStreamProxy *weakSelf = self;
         
+        static const char *const hum[] = { "Kb", "Mb", "Gb"};
+        static const UInt64 byte[] = {1024, 1048576, 1073741824};
+        _audioStream.onUpdateReceivedSize = ^(UInt64 receivedBufferSize) {
+            for (int x = 2; x>=0; x--){
+                if (receivedBufferSize>=byte[x])
+                {
+                    NSLog(@"onUpdateReceivedSize %0.2f %s", (float)receivedBufferSize/byte[x], hum[x]);
+                    break;
+                }
+            }
+        };
         _audioStream.onCompletion = ^() {
             if (weakSelf.audioController.enableDebugOutput) {
                 NSLog(@"[FSAudioController.m:%i] onCompletion(): %@", __LINE__, weakSelf.url);

--- a/Common/FSAudioStream.h
+++ b/Common/FSAudioStream.h
@@ -409,6 +409,10 @@ NSString*             freeStreamerReleaseVersion();
  */
 @property (copy) void (^onFailure)(FSAudioStreamError error, NSString *errorDescription);
 /**
+ *  Called upon update receviced buffer size.
+ */
+@property (copy) void (^onUpdateReceivedSize)(UInt64 receivedSize);
+/**
  * The property has the low-level stream configuration.
  */
 @property (readonly) FSStreamConfiguration *configuration;

--- a/Common/FSAudioStream.h
+++ b/Common/FSAudioStream.h
@@ -53,6 +53,9 @@ typedef enum {
     kFsAudioStreamSeeking,
     kFSAudioStreamEndOfFile,
     kFsAudioStreamFailed,
+    kFsAudioStreamStartRetry,
+    kFsAudioStreamRetrySuccess,
+    kFsAudioStreamAllRetryFailed,
     kFsAudioStreamPlaybackCompleted,
     kFsAudioStreamUnknownState
 } FSAudioStreamState;
@@ -293,6 +296,11 @@ NSString*             freeStreamerReleaseVersion();
 - (void)setPlayRate:(float)playRate;
 
 /**
+ * For clean retry count
+ * @param restartCount The retry count.
+ */
+- (void)setRetryCount:(int)retryCount;
+/**
  * Returns the playback status: YES if the stream is playing, NO otherwise.
  */
 - (BOOL)isPlaying;
@@ -301,6 +309,11 @@ NSString*             freeStreamerReleaseVersion();
  * Cleans all cached data from the persistent storage.
  */
 - (void)expungeCache;
+
+/**
+ * Get current retry count.
+ */
+- (NSUInteger)retryCount;
 
 /**
  * The stream URL.

--- a/Common/FSAudioStream.mm
+++ b/Common/FSAudioStream.mm
@@ -1399,12 +1399,11 @@ void AudioStreamStateObserver::audioStreamStateChanged(astreamer::Audio_Stream::
             notificationHandler = @selector(notifyPlaybackStopped);
             break;
         case astreamer::Audio_Stream::BUFFERING:
+            priv.internetConnectionAvailable = YES;            
             notificationHandler = @selector(notifyPlaybackBuffering);
             break;
         case astreamer::Audio_Stream::PLAYING:
-            priv.internetConnectionAvailable = YES;
             priv.restartCount = 0;
-            
             notificationHandler = @selector(notifyPlaybackPlaying);
             break;
         case astreamer::Audio_Stream::PAUSED:

--- a/Common/FSAudioStream.mm
+++ b/Common/FSAudioStream.mm
@@ -211,6 +211,7 @@ public:
 @property (nonatomic,assign) BOOL wasDisconnected;
 @property (nonatomic,assign) BOOL wasContinuousStream;
 @property (nonatomic,assign) BOOL internetConnectionAvailable;
+@property (nonatomic,assign) NSUInteger maxRetryCount;
 @property (nonatomic,assign) NSUInteger restartCount;
 @property (readonly) size_t prebufferedByteCount;
 @property (readonly) FSSeekByteOffset currentSeekByteOffset;
@@ -298,6 +299,7 @@ public:
                                                      name:AVAudioSessionInterruptionNotification
                                                    object:nil];
 #endif
+        _maxRetryCount = 3;
     }
     return self;
 }
@@ -712,6 +714,7 @@ public:
 
 - (void)notifyPlaybackBuffering
 {
+    self.internetConnectionAvailable = YES;
     [self notifyStateChange:kFsAudioStreamBuffering];
 }
 
@@ -723,7 +726,10 @@ public:
         fsAudioStreamPrivateActiveSessions[[NSNumber numberWithUnsignedLong:(unsigned long)self]] = @"";
     }
 #endif
-    
+    if (self.restartCount > 0){
+        [self notifyStateChange:kFsAudioStreamRetrySuccess];
+    }
+    self.restartCount = 0;
     [self notifyStateChange:kFsAudioStreamPlaying];
 }
 
@@ -800,10 +806,11 @@ public:
         return;
     }
     
-    if (self.restartCount >= 3) {
+    if (self.restartCount >= self.maxRetryCount) {
 #if defined(DEBUG) || (TARGET_IPHONE_SIMULATOR)
         NSLog(@"FSAudioStream: Restart count %lu. Giving up.", (unsigned long)_restartCount);
 #endif
+        [self notifyStateChange:kFsAudioStreamAllRetryFailed];
         return;
     }
     
@@ -811,6 +818,7 @@ public:
     NSLog(@"FSAudioStream: Attempting restart.");
 #endif
     
+    [self notifyStateChange:kFsAudioStreamStartRetry];
     [NSTimer scheduledTimerWithTimeInterval:1
                                      target:self
                                    selector:@selector(play)
@@ -1144,6 +1152,9 @@ public:
 {
     [_private setPlayRate:playRate];
 }
+- (void)setRetryCount:(int)retryCount{
+    _private.restartCount = retryCount;
+}
 
 - (BOOL)isPlaying
 {
@@ -1154,6 +1165,10 @@ public:
 {
     [_private expungeCache];
 }
+- (NSUInteger)retryCount{
+    return _private.restartCount;
+}
+
 
 - (FSStreamPosition)currentTimePlayed
 {
@@ -1399,11 +1414,9 @@ void AudioStreamStateObserver::audioStreamStateChanged(astreamer::Audio_Stream::
             notificationHandler = @selector(notifyPlaybackStopped);
             break;
         case astreamer::Audio_Stream::BUFFERING:
-            priv.internetConnectionAvailable = YES;            
             notificationHandler = @selector(notifyPlaybackBuffering);
             break;
         case astreamer::Audio_Stream::PLAYING:
-            priv.restartCount = 0;
             notificationHandler = @selector(notifyPlaybackPlaying);
             break;
         case astreamer::Audio_Stream::PAUSED:

--- a/astreamer/audio_stream.h
+++ b/astreamer/audio_stream.h
@@ -64,6 +64,7 @@ public:
     void open(Input_Stream_Position *position);
     void close(bool closeParser);
     void pause();
+    void closeForNetworkDisconnectAndBufferEmpty();
     
     void startCachedDataPlayback();
     
@@ -213,6 +214,8 @@ public:
     virtual void audioStreamErrorOccurred(int errorCode, CFStringRef errorDescription) = 0;
     virtual void audioStreamMetaDataAvailable(std::map<CFStringRef,CFStringRef> metaData) = 0;
     virtual void samplesAvailable(AudioBufferList samples, AudioStreamPacketDescription description) = 0;
+    virtual void audioStreamReceivedSize(UInt64 receivedSize) = 0;
+    virtual void audioStreamBufferEmpty() = 0;
 };    
 
 } // namespace astreamer


### PR DESCRIPTION
1. add onUpdateReceivedSize to show how much data is received
2. fix network disconnect and wait unit the buffer ran out then reopen the http_stream to restart the streaming
 
2 is trying to fix issue in following situation
 a. Start to play any web music (streaming or not) but still under data transferring with WIFI only ( other network are disable)
 b. Shut down the WIFI, music is still playing since there are still some buffer can use for playing
 c. Turn on LTE/3G, the network is come back. When the buffer ran out, the streaming doesn't come back 

After my tracing the code I found
when network changed is detected in - (void)reachabilityChanged:(NSNotification *)note and call [self attemptRestart] try to restart the streaming.
In [self attemptRestart] it call "- (void)play".
In "- (void)play" it call _audioStream->open()  try to reopen the audio stream.

void Audio_Stream::open(Input_Stream_Position *position)
{
/// Since the buffer is still running here will return directly
    if (m_inputStreamRunning || m_audioStreamParserRunning) {  
        AS_TRACE("%s: already running: return\n", __PRETTY_FUNCTION__);
        return;
    }

And I don't want to waste the buffer, so I added the code to retry after the buffer ran out.


