### PR TITLE
Implement defaultContentLength property

### DIFF
--- a/Common/FSAudioStream.h
+++ b/Common/FSAudioStream.h
@@ -372,6 +372,11 @@ NSString*             freeStreamerReleaseVersion();
  */
 @property (nonatomic,readonly) NSString *suggestedFileExtension;
 /**
+ * Sets a default content length for the stream.  Used if
+ * the stream content-length is not available.
+ */
+@property (nonatomic, assign) UInt64 defaultContentLength;
+/**
  * The property has the content length of the stream (in bytes). The length is zero if
  * the stream is continuous.
  */

--- a/Common/FSAudioStream.mm
+++ b/Common/FSAudioStream.mm
@@ -234,6 +234,7 @@ public:
 @property (nonatomic,assign) NSString *defaultContentType;
 @property (readonly) NSString *contentType;
 @property (readonly) NSString *suggestedFileExtension;
+@property (nonatomic, assign) UInt64 defaultContentLength;
 @property (readonly) UInt64 contentLength;
 @property (nonatomic,assign) NSURL *outputFile;
 @property (nonatomic,assign) BOOL wasInterrupted;
@@ -540,6 +541,11 @@ public:
         suggestedFileExtension = @"aac";
     }
     return suggestedFileExtension;
+}
+
+- (UInt64)defaultContentLength
+{
+    return _audioStream->defaultContentLength();
 }
 
 - (UInt64)contentLength
@@ -1263,6 +1269,13 @@ public:
     NSAssert([NSThread isMainThread], @"FSAudioStream.suggestedFileExtension needs to be called in the main thread");
     
     return [_private suggestedFileExtension];
+}
+
+- (UInt64)defaultContentLength
+{
+    NSAssert([NSThread isMainThread], @"FSAudioStream.defaultContentLength needs to be called in the main thread");
+    
+    return [_private defaultContentLength];
 }
 
 - (UInt64)contentLength

--- a/astreamer/audio_stream.cpp
+++ b/astreamer/audio_stream.cpp
@@ -554,6 +554,11 @@ void Audio_Stream::setSeekOffset(float offset)
 {
     m_seekOffset = offset;
 }
+ 
+void Audio_Stream::setDefaultContentLength(UInt64 defaultContentLength)
+{
+    m_defaultContentLength = defaultContentLength;
+}
     
 void Audio_Stream::setContentLength(UInt64 contentLength)
 {
@@ -1071,11 +1076,19 @@ void Audio_Stream::closeAudioQueue()
     delete m_audioQueue, m_audioQueue = 0;
 }
     
+UInt64 Audio_Stream::defaultContentLength()
+{
+    return m_defaultContentLength;
+}
+    
 UInt64 Audio_Stream::contentLength()
 {
     if (m_contentLength == 0) {
         if (m_inputStream) {
             m_contentLength = m_inputStream->contentLength();
+            if (m_contentLength == 0) {
+                m_contentLength = defaultContentLength();
+            }
         }
     }
     return m_contentLength;

--- a/astreamer/audio_stream.h
+++ b/astreamer/audio_stream.h
@@ -81,6 +81,7 @@ public:
     void setStrictContentTypeChecking(bool strictChecking);
     void setDefaultContentType(CFStringRef defaultContentType);
     void setSeekOffset(float offset);
+    void setDefaultContentLength(UInt64 defaultContentLength);
     void setContentLength(UInt64 contentLength);
     void setPreloading(bool preloading);
     bool isPreloading();
@@ -99,6 +100,7 @@ public:
     bool strictContentTypeChecking();
     float bitrate();
     
+    UInt64 defaultContentLength();
     UInt64 contentLength();
     int playbackDataCount();
     int audioQueueNumberOfBuffersInUse();
@@ -133,6 +135,7 @@ private:
     bool m_ignoreDecodeQueueSize;
     bool m_audioQueueConsumedPackets;
     
+    UInt64 m_defaultContentLength;
     UInt64 m_contentLength;
     UInt64 m_bytesReceived;
     


### PR DESCRIPTION
@muhku I started working on this but have hit a bit of a dead end and wanted to see if you would be able to help me at all?

We sometimes have http endpoints which don't reliably return a content-length.  Google Drive is notorious for this.  They will return a content-length every 3rd time or so, which is a huge pain.  Without the content-length, FreeStreamer won't show a reliable duration/progress/seek. 

We would like to be able to use FreeStreamer in these cases.  So, it seemed like it might be acceptable to add a "defaultContentLength" property, that would override the internal content-length if an HTTP endpoint didn't return one.  We always know the size of the file in bytes from their API, so we have the info available to us.

I've added the property here in this PR, but I suspect the point where I do the actual overriding (getter for contentLength) isn't the right place.