### PR TITLE
ignore content type if request code was not successful

### DIFF
--- a/Common/FSCheckContentTypeRequest.m
+++ b/Common/FSCheckContentTypeRequest.m
@@ -104,7 +104,11 @@
     _format = kFSFileFormatUnknown;
     _playlist = NO;
     
-    if ([_contentType isEqualToString:@"audio/mpeg"]) {
+    if (((NSHTTPURLResponse*)response).statusCode / 100 != 2) {
+        //ignore response if statusCode is not 2xx
+        [self guessContentTypeByUrl:response];
+    }
+    else if ([_contentType isEqualToString:@"audio/mpeg"]) {
         _format = kFSFileFormatMP3;
     } else if ([_contentType isEqualToString:@"audio/x-wav"]) {
         _format = kFSFileFormatWAVE;


### PR DESCRIPTION
Not exactly sure why it happens, but FSCheckContentTypeRequest receives 403 code and xml content type, and then it tries FSXMLHttpRequest which for some reason returns 200 and the whole track is downloaded.

In my opinion it would make sense to ignore returned content type if the code is not 2xx.