### PR TITLE
Fixed a crash when audio playing completes

### DIFF
--- a/astreamer/audio_queue.cpp
+++ b/astreamer/audio_queue.cpp
@@ -496,13 +496,13 @@ void Audio_Queue::audioQueueOutputCallback(void *inClientData, AudioQueueRef inA
         audioQueue->m_delegate->audioQueueBuffersEmpty();
     } else {
         pthread_mutex_unlock(&audioQueue->m_bufferInUseMutex);
+        
+        if (audioQueue->m_delegate) {
+            audioQueue->m_delegate->audioQueueFinishedPlayingPacket();
+        }
     }
     
     AQ_LOCK_TRACE("audioQueueOutputCallback: unlock\n");
-    
-    if (audioQueue->m_delegate) {
-        audioQueue->m_delegate->audioQueueFinishedPlayingPacket();
-    }
 }
 
 void Audio_Queue::audioQueueIsRunningCallback(void *inClientData, AudioQueueRef inAQ, AudioQueuePropertyID inID)


### PR DESCRIPTION
There was a bug where the call to `audioQueueFinishedPlayingPacket` crashed with "BAD ACCESS" when the playbeck finishes.

moved the call to `audioQueueFinishedPlayingPacket` only when playbeck is not done.

I do not actually program in C++ so I might have understood it wrong and did something bad here, but it solved the issue for me...