### PR TITLE
Add more playlist maniuplation operations to FSAudioController and fix [FSAudioStream duration]

### DIFF
--- a/Common/FSAudioController.h
+++ b/Common/FSAudioController.h
@@ -112,6 +112,22 @@
 - (void)addItem:(FSPlaylistItem *)item;
 
 /**
+ * Adds an item to the playlist at a specific position.
+ *
+ * @param item The playlist item to be added.
+ * @Param index The location in the playlist to place the new item
+ */
+- (void)insertItem:(FSPlaylistItem *)item atIndex:(NSInteger)index;
+
+/**
+ * Moves an item already in the playlist to a different position in the playlist
+ *
+ * @param from The original index of the track to move
+ * @Param to The destination of the the track at the index specified in `from`
+ */
+- (void)moveItemAtIndex:(NSUInteger)from toIndex:(NSUInteger)to;
+
+/**
  * Replaces a playlist item.
  *
  * @param index The index of the playlist item to be replaced.

--- a/Common/FSAudioController.m
+++ b/Common/FSAudioController.m
@@ -557,6 +557,38 @@
     [_streams addObject:proxy];
 }
 
+- (void)insertItem:(FSPlaylistItem *)item atIndex:(NSInteger)index
+{
+    if (!item) {
+        return;
+    }
+    
+    if (index > self.playlistItems.count) {
+        return;
+    }
+    
+    if(self.playlistItems.count == 0 && index == 0) {
+        [self addItem:item];
+    }
+    
+    [self.playlistItems insertObject:item
+                             atIndex:index];
+    
+    FSAudioStreamProxy *proxy = [[FSAudioStreamProxy alloc] initWithAudioController:self];
+    proxy.url = item.url;
+    
+    if (self.enableDebugOutput) {
+        NSLog(@"[FSAudioController.m:%i] insertItem:atIndex. Adding stream proxy for %@ at %ld", __LINE__, proxy.url, index);
+    }
+    
+    [_streams insertObject:proxy
+                   atIndex:index];
+
+    if(index <= self.currentPlaylistItemIndex) {
+        _currentPlaylistItemIndex++;
+    }
+}
+
 - (void)replaceItemAtIndex:(NSUInteger)index withItem:(FSPlaylistItem *)item
 {
     NSUInteger count = [self countOfItems];
@@ -580,6 +612,36 @@
     proxy.url = item.url;
     
     [_streams replaceObjectAtIndex:index withObject:proxy];
+}
+
+- (void)moveItemAtIndex:(NSUInteger)from toIndex:(NSUInteger)to {
+    NSUInteger count = [self countOfItems];
+    
+    if (count == 0) {
+        return;
+    }
+    
+    if (from >= count || to >= count) {
+        return;
+    }
+    
+    if(from == self.currentPlaylistItemIndex) {
+        _currentPlaylistItemIndex = to;
+    }
+    else if(from < self.currentPlaylistItemIndex && to > self.currentPlaylistItemIndex) {
+        _currentPlaylistItemIndex--;
+    }
+    else if(from > self.currentPlaylistItemIndex && to <= self.currentPlaylistItemIndex) {
+        _currentPlaylistItemIndex++;
+    }
+    
+    id object = [self.playlistItems objectAtIndex:from];
+    [self.playlistItems removeObjectAtIndex:from];
+    [self.playlistItems insertObject:object atIndex:to];
+    
+    id obj = [_streams objectAtIndex:from];
+    [_streams removeObjectAtIndex:from];
+    [_streams insertObject:obj atIndex:to];
 }
 
 - (void)removeItemAtIndex:(NSUInteger)index

--- a/Common/FSAudioStream.mm
+++ b/Common/FSAudioStream.mm
@@ -1503,6 +1503,9 @@ public:
         pos.minute = m;
         pos.second = s;
     }
+
+    pos.playbackTimeInSeconds = durationInSeconds;
+
     return pos;
 }
 


### PR DESCRIPTION
This pull request adds two new methods to `FSAudioController` and fixes a bug in `[FSAudioStream duration]`.

The bug fix is very simple. The `playbackTimeInSeconds` member of the `FSStreamPosition` struct is never populated like it is in `[FSAudioStream currentTimePlayed]`.

The two new methods added to `FSAudioController` allow for more complex modification of the playlist and mirrors operations typically needed for queue-based music playback apps:

* `insertItem:atIndex:`: this method is very similar to `addItem:` but allows you to specify at which index to insert the new item.
* `moveItemAtIndex:toIndex:`: this method allows you to move any playback item, including the currently playing item, from anywhere in the playlist to a new location

Both of these methods can be used during playback. In addition, these methods properly handle and adjust the currently playing index in response to the modifications made to the playlist.