### PR TITLE
Issue #258: Make maxRetryCount public

### DIFF
--- a/FreeStreamer/FreeStreamer/FSAudioStream.h
+++ b/FreeStreamer/FreeStreamer/FSAudioStream.h
@@ -529,6 +529,12 @@ NSString*             freeStreamerReleaseVersion();
  */
 @property (nonatomic,readonly) NSUInteger retryCount;
 /**
+ * Holds the maximum amount of playback retries that will be 
+ * performed before entering kFsAudioStreamRetryingFailed state.
+ * Default is 3.
+ */
+@property (nonatomic,assign) NSUInteger maxRetryCount;
+/**
  * The property determines the current audio levels.
  */
 @property (nonatomic,readonly) FSLevelMeterState levels;

--- a/FreeStreamer/FreeStreamer/FSAudioStream.mm
+++ b/FreeStreamer/FreeStreamer/FSAudioStream.mm
@@ -1681,6 +1681,20 @@ public:
     return [_private description];
 }
 
+-(NSUInteger)maxRetryCount
+{
+    NSAssert([NSThread isMainThread], @"FSAudioStream.maxRetryCount needs to be called in the main thread");
+    
+    return [_private maxRetryCount];
+}
+
+-(void)setMaxRetryCount:(NSUInteger)maxRetryCount
+{
+    NSAssert([NSThread isMainThread], @"FSAudioStream.setMaxRetryCount needs to be called in the main thread");
+    
+    [_private setMaxRetryCount:maxRetryCount];
+}
+
 @end
 
 /*


### PR DESCRIPTION
Hello!

Made this property public and put MainThread-asserts on the getter and setter.

It should be possible to put this property in the Configuration as well if you'd want to?