### PR TITLE
Fix for AVAudioSession bug

### DIFF
--- a/FreeStreamer/FreeStreamer/FSAudioController.m
+++ b/FreeStreamer/FreeStreamer/FSAudioController.m
@@ -723,9 +723,9 @@
         }
         [self.audioStream stop];
         
-        self.currentPlaylistItemIndex = self.currentPlaylistItemIndex + 1;
-        
         [self deactivateInactivateStreams:self.currentPlaylistItemIndex];
+        
+        self.currentPlaylistItemIndex = self.currentPlaylistItemIndex + 1;
         
         [self play];
     }


### PR DESCRIPTION
FIXED ERROR:    [0x1a088d000] AVAudioSession.mm:697: -[AVAudioSession setActive:withOptions:error:]: Deactivating an audio session that has running I/O. All I/O should be stopped or paused prior to deactivating the audio session.