### PR TITLE
Fixing sizeof which would cause crash

### DIFF
--- a/Additions/FSFrequencyPlotView.m
+++ b/Additions/FSFrequencyPlotView.m
@@ -41,7 +41,7 @@
     
     _count = MIN(kFSFrequencyPlotViewMaxCount, count);
 
-    memcpy(_levels, levels, sizeof(levels) * _count);
+    memcpy(_levels, levels, sizeof(float) * _count);
     
     [self setNeedsDisplay];
 }


### PR DESCRIPTION
The `sizeof` was wrong and was getting the size of the float pointer and not the float.
