### PR TITLE
Allow removal of the current item if it is not playing

### DIFF
--- a/FreeStreamer/FreeStreamer/FSAudioController.m
+++ b/FreeStreamer/FreeStreamer/FSAudioController.m
@@ -652,7 +652,7 @@
         return;
     }
     
-    if (self.currentPlaylistItemIndex == index) {
+    if (self.currentPlaylistItemIndex == index && self.isPlaying) {
         // If the item is currently playing, do not allow the removal
         return;
     }


### PR DESCRIPTION
As long as the current source is stopped we should be able to clear out the playlist items.  This change adds a check against the playing state in removeItemAtIndex: to support this.