### PR TITLE
Fixed adding playlist items twice when using insertion method

### DIFF
--- a/FreeStreamer/FreeStreamer/FSAudioController.m
+++ b/FreeStreamer/FreeStreamer/FSAudioController.m
@@ -570,15 +570,16 @@
     if(self.playlistItems.count == 0 && index == 0) {
         [self addItem:item];
     }
-    
-    [self.playlistItems insertObject:item
-                             atIndex:index];
-    
-    FSAudioStreamProxy *proxy = [[FSAudioStreamProxy alloc] initWithAudioController:self];
-    proxy.url = item.url;
-    
-    [_streams insertObject:proxy
-                   atIndex:index];
+    else {
+        [self.playlistItems insertObject:item
+                                 atIndex:index];
+        
+        FSAudioStreamProxy *proxy = [[FSAudioStreamProxy alloc] initWithAudioController:self];
+        proxy.url = item.url;
+        
+        [_streams insertObject:proxy
+                       atIndex:index];
+    }    
 
     if(index <= self.currentPlaylistItemIndex) {
         _currentPlaylistItemIndex++;


### PR DESCRIPTION
In the method insertItem:atIndex: the item will be added to playlist twice if the playlist is empty and we add item at 0 index.
First, it will be added here:
```
if(self.playlistItems.count == 0 && index == 0) {
        [self addItem:item];
}
```
and for second, here:
```
[self.playlistItems insertObject:item
                                 atIndex:index];
        
        FSAudioStreamProxy *proxy = [[FSAudioStreamProxy alloc] initWithAudioController:self];
        proxy.url = item.url;
        
        [_streams insertObject:proxy
                       atIndex:index];
```
So, I updated the condition by enclosing second addition in "else" case.
It is temporary workaround for this by using addItem method for empty list.