### PR TITLE
Fixed to not change currentPlaylistItemIndex if inserting of item means adding as first element

### DIFF
--- a/FreeStreamer/FreeStreamer/FSAudioController.m
+++ b/FreeStreamer/FreeStreamer/FSAudioController.m
@@ -569,17 +569,17 @@
     
     if(self.playlistItems.count == 0 && index == 0) {
         [self addItem:item];
+        return;
     }
-    else {
-        [self.playlistItems insertObject:item
-                                 atIndex:index];
-        
-        FSAudioStreamProxy *proxy = [[FSAudioStreamProxy alloc] initWithAudioController:self];
-        proxy.url = item.url;
-        
-        [_streams insertObject:proxy
-                       atIndex:index];
-    }    
+    
+    [self.playlistItems insertObject:item
+                             atIndex:index];
+    
+    FSAudioStreamProxy *proxy = [[FSAudioStreamProxy alloc] initWithAudioController:self];
+    proxy.url = item.url;
+    
+    [_streams insertObject:proxy
+                   atIndex:index];
 
     if(index <= self.currentPlaylistItemIndex) {
         _currentPlaylistItemIndex++;


### PR DESCRIPTION
Fixed to not change currentPlaylistItemIndex if inserting of item means adding as first element

If inserting as first element - thatn means just adding - the currentPlaylistItemIndex is already equals zero and we do not want to change it.
We need to change it if it was inserting because there was shift of items.