### PR TITLE
Fixed a bug where disabling preloading prevents automatically play next item.

### DIFF
--- a/FreeStreamer/FreeStreamer/FSAudioController.m
+++ b/FreeStreamer/FreeStreamer/FSAudioController.m
@@ -569,17 +569,17 @@
     
     if(self.playlistItems.count == 0 && index == 0) {
         [self addItem:item];
+        return;
     }
-    else {
-        [self.playlistItems insertObject:item
-                                 atIndex:index];
-        
-        FSAudioStreamProxy *proxy = [[FSAudioStreamProxy alloc] initWithAudioController:self];
-        proxy.url = item.url;
-        
-        [_streams insertObject:proxy
-                       atIndex:index];
-    }    
+    
+    [self.playlistItems insertObject:item
+                             atIndex:index];
+    
+    FSAudioStreamProxy *proxy = [[FSAudioStreamProxy alloc] initWithAudioController:self];
+    proxy.url = item.url;
+    
+    [_streams insertObject:proxy
+                   atIndex:index];
 
     if(index <= self.currentPlaylistItemIndex) {
         _currentPlaylistItemIndex++;

--- a/FreeStreamer/FreeStreamer/FSAudioController.m
+++ b/FreeStreamer/FreeStreamer/FSAudioController.m
@@ -191,21 +191,21 @@
         return;
     }
     
-    if (!self.preloadNextPlaylistItemAutomatically) {
-        // No preloading wanted, skip
-        if (self.enableDebugOutput) {
-            NSLog(@"[FSAudioController.m:%i] Preloading disabled, return.", __LINE__);
-        }
-        
-        return;
-    }
-    
     NSDictionary *dict = [notification userInfo];
     int state = [[dict valueForKey:FSAudioStreamNotificationKey_State] intValue];
     
     if (state == kFSAudioStreamEndOfFile) {
         if (self.enableDebugOutput) {
             NSLog(@"[FSAudioController.m:%i] EOF reached for %@", __LINE__, self.audioStream.url);
+        }
+        
+        if (!self.preloadNextPlaylistItemAutomatically) {
+            // No preloading wanted, skip
+            if (self.enableDebugOutput) {
+                NSLog(@"[FSAudioController.m:%i] Preloading disabled, return.", __LINE__);
+            }
+            
+            return;
         }
         
         // Reached EOF for this stream, do we have another item waiting in the playlist?


### PR DESCRIPTION
If **preloadNextPlaylistItemAutomatically** flag is disabled then **audioStreamStateDidChange:** method will never play next item on _kFsAudioStreamPlaybackCompleted_ state because guard method will return. I have moved that guard into the case for making preload.