### PR TITLE
Check for automaticAudioSessionhandlingEnabled in FSAudioController

### DIFF
--- a/FreeStreamer/FreeStreamer/FSAudioController.m
+++ b/FreeStreamer/FreeStreamer/FSAudioController.m
@@ -258,9 +258,11 @@
         
         self.songSwitchInProgress = NO;
         
+        if (self.configuration.automaticAudioSessionHandlingEnabled) {
 #if (__IPHONE_OS_VERSION_MIN_REQUIRED >= 60000)
-        [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:nil];
+            [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:nil];
 #endif
+        }
         [self setAudioSessionActive:YES];
     }
 }
@@ -283,13 +285,15 @@
 
 - (void)setAudioSessionActive:(BOOL)active
 {
+    if (self.configuration.automaticAudioSessionHandlingEnabled) {
 #if (__IPHONE_OS_VERSION_MIN_REQUIRED >= 60000)
-    [[AVAudioSession sharedInstance] setActive:active withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation error:nil];
+        [[AVAudioSession sharedInstance] setActive:active withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation error:nil];
 #else
 #if (__IPHONE_OS_VERSION_MIN_REQUIRED >= 40000)
-    [[AVAudioSession sharedInstance] setActive:active error:nil];
+        [[AVAudioSession sharedInstance] setActive:active error:nil];
 #endif
 #endif
+    }
 }
 
 /*


### PR DESCRIPTION
The `FSAudioController` does not check for `automaticAudioSessionhandlingEnabled` before handling the `AVAudioSession`. This has caused issues for me, leading to race conditions where an AVAudioSession was disabled with running I/O. 

Would this be a viable solution? I'm not sure how this might affect other use cases.

This touches on issues in #191, #190 and possibly #223