### PR TITLE
Optimize HTTP stream data access and fix retry bug

### DIFF
--- a/FreeStreamer/FreeStreamer/audio_queue.cpp
+++ b/FreeStreamer/FreeStreamer/audio_queue.cpp
@@ -127,6 +127,11 @@ void Audio_Queue::stop()
     stop(true);
 }
     
+Audio_Queue::State Audio_Queue::state()
+{
+    return m_state;
+}
+    
 float Audio_Queue::volume()
 {
     if (!m_outAQ) {

--- a/FreeStreamer/FreeStreamer/audio_queue.h
+++ b/FreeStreamer/FreeStreamer/audio_queue.h
@@ -41,6 +41,8 @@ public:
     void stop(bool stopImmediately);
     void stop();
     
+    State state();
+    
     float volume();
     
     void setVolume(float volume);

--- a/FreeStreamer/FreeStreamer/audio_stream.cpp
+++ b/FreeStreamer/FreeStreamer/audio_stream.cpp
@@ -1538,7 +1538,14 @@ bool Audio_Stream::decoderShouldRun()
 {
     const Audio_Stream::State state = this->state();
     
+    /* if audio queue paused, decoder should not run */
+    bool isAudioQueuePaused = false;
+    if (m_audioQueue) {
+        isAudioQueuePaused = m_audioQueue->state() == m_audioQueue->PAUSED;
+    }
+    
     pthread_mutex_lock(&m_streamStateMutex);
+    
     
     if (m_preloading ||
         !m_decoderShouldRun ||
@@ -1549,7 +1556,8 @@ bool Audio_Stream::decoderShouldRun()
         state == SEEKING ||
         state == FAILED ||
         state == PLAYBACK_COMPLETED ||
-        m_dstFormat.mBytesPerPacket == 0) {
+        m_dstFormat.mBytesPerPacket == 0 ||
+        isAudioQueuePaused ) {
         pthread_mutex_unlock(&m_streamStateMutex);
         return false;
     } else {

--- a/FreeStreamer/FreeStreamer/audio_stream.h
+++ b/FreeStreamer/FreeStreamer/audio_stream.h
@@ -139,6 +139,8 @@ private:
     UInt64 m_originalContentLength;
     UInt64 m_bytesReceived;
     
+    AS_Playback_Position m_currentPlaybackPosition; /* record where it has played to */
+    
     State m_state;
     Input_Stream *m_inputStream;
     Audio_Queue *m_audioQueue;

--- a/FreeStreamer/FreeStreamer/http_stream.cpp
+++ b/FreeStreamer/FreeStreamer/http_stream.cpp
@@ -141,6 +141,8 @@ bool HTTP_Stream::open(const Input_Stream_Position& position)
     /* Reset state */
     m_position = position;
     
+    HS_TRACE("open position: %lld, %lld\n", position.start, position.end);
+    
     m_readPending = false;
     m_httpHeadersParsed = false;
     
@@ -233,7 +235,11 @@ void HTTP_Stream::openTimerCallback(CFRunLoopTimerRef timer, void *info)
     if (!THIS->m_isReadedData) {
         HS_TRACE("reopen debug: try reopen stream times %ld\n",THIS->m_reopenTimes);
         THIS->close();
-        THIS->open();
+        if ( THIS->m_position.end >= THIS->m_position.start) {
+            THIS->open(THIS->m_position);
+        } else {
+            THIS->open();
+        }
     }
 }
     

--- a/FreeStreamer/FreeStreamer/http_stream.h
+++ b/FreeStreamer/FreeStreamer/http_stream.h
@@ -33,6 +33,8 @@ private:
     CFReadStreamRef m_readStream;
     bool m_scheduledInRunLoop;
     bool m_readPending;
+    CFRunLoopTimerRef m_openTimer;
+    bool m_isReadedData;
     Input_Stream_Position m_position;
     
     /* HTTP headers */
@@ -68,6 +70,7 @@ private:
     CFStringRef createMetaDataStringWithMostReasonableEncoding(const UInt8 *bytes, const CFIndex numBytes);
     
     static void readCallBack(CFReadStreamRef stream, CFStreamEventType eventType, void *clientCallBackInfo);
+    static void openTimerCallback(CFRunLoopTimerRef timer, void *info);
     
 public:
     HTTP_Stream();

--- a/FreeStreamer/FreeStreamer/http_stream.h
+++ b/FreeStreamer/FreeStreamer/http_stream.h
@@ -34,6 +34,7 @@ private:
     bool m_scheduledInRunLoop;
     bool m_readPending;
     CFRunLoopTimerRef m_openTimer;
+    size_t m_reopenTimes;
     bool m_isReadedData;
     Input_Stream_Position m_position;
     
@@ -71,6 +72,8 @@ private:
     
     static void readCallBack(CFReadStreamRef stream, CFStreamEventType eventType, void *clientCallBackInfo);
     static void openTimerCallback(CFRunLoopTimerRef timer, void *info);
+    
+    void resetOpenTimer(bool needResetReadedFlag);
     
 public:
     HTTP_Stream();


### PR DESCRIPTION
1, Sometimes, freeStreamer cause a lot time to start play or even can not play because HTTP stream opened successfully but do not have data available for quite a long time, properly stuck or whatever. So it need  to try reopen the HTTP stream to access data.

2, When freeStreamer playing sound through HTTP,  network become bad such as 100% loss. It started buffer and failed. Then it started retry. if retry succeed, it play from head. It should play from where already played to.
So, it need to record where itself already played to.