### PR TITLE
add m_playingPacketIdentifier

### DIFF
--- a/FreeStreamer/FreeStreamer/audio_stream.h
+++ b/FreeStreamer/FreeStreamer/audio_stream.h
@@ -159,6 +159,7 @@ private:
     UInt8 *m_outputBuffer;
     
     UInt64 m_packetIdentifier;
+    UInt64 m_playingPacketIdentifier;
     UInt64 m_dataOffset;
     float m_seekOffset;
     size_t m_bounceCount;


### PR DESCRIPTION
add `m_playingPacketIdentifier` for avoid modifying `m_packetIdentifier` when stream still creating packet