### PR TITLE
[Fix] Fixed silence after seek attempt. Issue #341

### DIFF
--- a/FreeStreamer/FreeStreamer/audio_stream.cpp
+++ b/FreeStreamer/FreeStreamer/audio_stream.cpp
@@ -746,7 +746,7 @@ out:
     
 void Audio_Stream::audioQueueStateChanged(Audio_Queue::State state)
 {
-    if (state == Audio_Queue::RUNNING) {
+    if (state == Audio_Queue::RUNNING && this->state() != SEEKING) {
         invalidateWatchdogTimer();
         setState(PLAYING);
         


### PR DESCRIPTION
Fixed issue with silence. Underlying stream is switching state to playing from seeking which leads to impossibility of fulfill this condition ```if (THIS->state() != SEEKING) {``` in ```void Audio_Stream::seekTimerCallback```