### PR TITLE
Fix the "double-tap play" bug

### DIFF
--- a/FreeStreamerDesktop/FreeStreamerDesktop/FSXPlayerViewController.m
+++ b/FreeStreamerDesktop/FreeStreamerDesktop/FSXPlayerViewController.m
@@ -61,12 +61,9 @@
          */
         [self.audioController pause];
         _paused = NO;
-    } else {
-        /*
-         * Not paused, just directly call play.
-         */
-        [self.audioController play];
     }
+    /* Resume play; fixes the "why do I have to click play twice?" bug */
+    [self.audioController play];
     
     [self.playButton setHidden:YES];
     [self.pauseButton setHidden:NO];


### PR DESCRIPTION
In thew desktop app, If the stream is paused, you have to hit play twice to get it to resume.
With this fix, you click it once and the stream rebuffers and resumes.