### PR TITLE
Respect IOHardware Buffer

### DIFF
--- a/Additions/FSFrequencyDomainAnalyzer.m
+++ b/Additions/FSFrequencyDomainAnalyzer.m
@@ -185,8 +185,11 @@
         
         if (dispatchLevels && [self.delegate respondsToSelector:@selector(frequenceAnalyzer:levelsAvailable:count:)]) {
             __weak FSFrequencyDomainAnalyzer *weakSelf = self;
-            
-            dispatch_async(dispatch_get_main_queue(), ^{
+
+            //respect hardware io buffer duration time
+            double bufferDuration = [[AVAudioSession sharedInstance] IOBufferDuration];
+
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, bufferDuration * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
                 FSFrequencyDomainAnalyzer *strongSelf = weakSelf;
                 
                 // Execute on the main thread

--- a/Additions/FSFrequencyDomainAnalyzer.m
+++ b/Additions/FSFrequencyDomainAnalyzer.m
@@ -8,6 +8,7 @@
 
 #import "FSFrequencyDomainAnalyzer.h"
 
+#import <AVFoundation/AVFoundation.h>
 #include <Accelerate/Accelerate.h>
 
 // Note: code has been adapted from https://github.com/douban/DOUAudioStreamer/blob/master/src/DOUAudioAnalyzer.m


### PR DESCRIPTION
For sending the samplesAvailable when it is played the HardwareIO Buffer Time is needed to respect. So i add this correct delay to the delegates dispatch.
