### PR TITLE
Fix crash of 389 ( https://github.com/muhku/FreeStreamer/issues/389 )

### DIFF
--- a/FreeStreamer/FreeStreamer/audio_stream.cpp
+++ b/FreeStreamer/FreeStreamer/audio_stream.cpp
@@ -938,10 +938,14 @@ void Audio_Stream::streamIsReadyRead()
     if (contentType) {
         m_contentType = CFStringCreateCopy(kCFAllocatorDefault, contentType);
         
-        if (kCFCompareEqualTo == CFStringCompareWithOptions(contentType, audioContentType, CFRangeMake(0, CFStringGetLength(audioContentType)),0)) {
-            matchesAudioContentType = true;
-        } else if (kCFCompareEqualTo == CFStringCompareWithOptions(contentType, videoContentType, CFRangeMake(0, CFStringGetLength(videoContentType)),0)) {
-            matchesAudioContentType = true;
+        if (CFStringGetLength(contentType) >= CFStringGetLength(audioContentType)) {
+            if (kCFCompareEqualTo == CFStringCompareWithOptions(contentType, audioContentType, CFRangeMake(0, CFStringGetLength(audioContentType)),0)) {
+                matchesAudioContentType = true;
+            }
+        } else if (CFStringGetLength(contentType) >= CFStringGetLength(videoContentType)) {
+            if (kCFCompareEqualTo == CFStringCompareWithOptions(contentType, videoContentType, CFRangeMake(0, CFStringGetLength(videoContentType)),0)) {
+                matchesAudioContentType = true;
+            }
         }
     }
     

--- a/FreeStreamer/FreeStreamer/audio_stream.cpp
+++ b/FreeStreamer/FreeStreamer/audio_stream.cpp
@@ -935,6 +935,7 @@ void Audio_Stream::streamIsReadyRead()
         CFRelease(m_contentType);
         m_contentType = 0;
     }
+    
     if (contentType) {
         m_contentType = CFStringCreateCopy(kCFAllocatorDefault, contentType);
         


### PR DESCRIPTION
if (kCFCompareEqualTo == CFStringCompareWithOptions(contentType, audioContentType, CFRangeMake(0, CFStringGetLength(audioContentType)),0)) {
          matchesAudioContentType = true;
}

The CFStringCompareWithOptions fun will crash when contentType length less than audioContentType .