### PR TITLE
Add tvos

### DIFF
--- a/FreeStreamer.podspec
+++ b/FreeStreamer.podspec
@@ -49,6 +49,7 @@ Pod::Spec.new do |s|
 	                          'FreeStreamer/FreeStreamer/FSPlaylistItem.h',
 	                          'FreeStreamer/FreeStreamer/FSXMLHttpRequest.h'
 	s.ios.frameworks        = 'CFNetwork', 'AudioToolbox', 'AVFoundation', 'MediaPlayer'
+	s.tvos.frameworks       = 'CFNetwork', 'AudioToolbox', 'AVFoundation', 'MediaPlayer'
 	s.osx.frameworks        = 'CFNetwork', 'AudioToolbox', 'AVFoundation'
 	s.libraries	        = 'xml2', 'stdc++'
 	s.xcconfig              = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2' }

--- a/FreeStreamer.podspec
+++ b/FreeStreamer.podspec
@@ -8,6 +8,7 @@ Pod::Spec.new do |s|
 	s.source                = { :git => 'https://github.com/muhku/FreeStreamer.git', :tag => s.version.to_s }
 	s.ios.deployment_target = '6.0'
 	s.osx.deployment_target = '10.7'
+	s.tvos.deployment_target = '9.0'
 	s.source_files          = 'FreeStreamer/FreeStreamer/FSAudioController.h',
 	                          'FreeStreamer/FreeStreamer/FSAudioController.m',
 	                          'FreeStreamer/FreeStreamer/FSAudioStream.h',


### PR DESCRIPTION
Hi,

tvos is missing in podspec. it works very good on tvos btw.

I know the Reachability cocopods version missing the tvos but they added it already on their github repo 2 years ago.

A correct PodFile looks like this to get it working. Reachability need installed before FreeStreamer

platform :ios, '9.0'
inhibit_all_warnings!

def shared_pods_app
    pod 'Reachability', :git => 'https://github.com/tonymillion/Reachability.git'
    pod 'FreeStreamer'
end

target 'myapp-tvos' do
    platform :tvos, '9.0'
    shared_pods_app
end

