### PR TITLE
fix bug #423 astreamer::Audio_Stream::cleanupCachedData() crash 80% background 

### DIFF
--- a/FreeStreamer/FreeStreamer/audio_stream.cpp
+++ b/FreeStreamer/FreeStreamer/audio_stream.cpp
@@ -367,6 +367,8 @@ void Audio_Stream::close(bool closeParser)
     m_queuedTail = 0;
     m_cachedDataSize = 0;
     m_numPacketsToRewind = 0;
+	
+	m_processedPackets.clear();
     
     pthread_mutex_unlock(&m_packetQueueMutex);
     


### PR DESCRIPTION
m_processedPackets cached all packages, after free packages ,we should clear the list
otherwise when run to method cleanupCachedData,m_processedPackets.back() will pop a freed object, which will cause crash